### PR TITLE
Work around bug in iOS7 where not setting status bar style hides clock

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -4,6 +4,7 @@
 	<script type='text/javascript' src='http://l42.eu/bootloader'></script>
 	<meta name="viewport" content="initial-scale=1.0" />
 	<meta name="apple-mobile-web-app-capable" content="yes" />
+	<meta name="apple-mobile-web-app-status-bar-style" content="black" />
 	<link rel="apple-touch-icon" href="/img/icon"/>
 </head>
 <body{{#cssClass}} class='{{cssClass}}'{{/cssClass}}>


### PR DESCRIPTION
It's helpful to know the current time when all times within the app are relative to it.

> If you don’t provide any apple-mobile-web-app-status-bar-style meta tag or if you provide one with the default value, the status bar will become black over black, so… just a black area on the screen (on some devices you will see just the battery icon). The user will not see the clock and all the other icons on the status bar.
> -- <cite>[Maximiliano Firt](http://www.mobilexweb.com/blog/safari-ios7-html5-problems-apis-review)</cite>
